### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ from the host machine.
 
 ### Code style analysis
 
-The code style is analyzed with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) and
+The code style is analyzed with [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) and
 [PSR-12 Ext coding standard](https://github.com/roslov/psr12ext). To run code style analysis:
 
 ```shell


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932