### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -32,6 +32,8 @@ jobs:
           - 8.2
           - 8.1
         laravel:
+          - 13.1.2
+          - 13.0.0
           - 12.11.2
           - 12.7.1
           - 12.0.11
@@ -43,6 +45,14 @@ jobs:
         # Incompatible combinations
         exclude:
           # Dependency incompatibility
+          - php: 8.1
+            laravel: 13.1.2
+          - php: 8.1
+            laravel: 13.0.0
+          - php: 8.2
+            laravel: 13.1.2
+          - php: 8.2
+            laravel: 13.0.0
           - php: 8.1
             laravel: 12.11.2
           - php: 8.1

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.1",
-        "illuminate/console": "^10.0|^11.0|^12.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "illuminate/database": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "roslov/migration-checker": "^1.0",
         "sebastian/diff": "^5.0|^6.0|^7.0|^8.0"
     },


### PR DESCRIPTION
## Summary
- Added `^13.0` to `illuminate/*` dependency constraints in `composer.json`
- Added Laravel 13.0.0 and 13.1.2 to the compatibility test matrix
- Excluded PHP 8.1 and 8.2 from Laravel 13 tests (Laravel 13 requires PHP 8.3+)

No source code changes needed — the package already uses stable Laravel APIs compatible with v13.